### PR TITLE
ButtonThemeBar

### DIFF
--- a/lib/flutter_duration_picker.dart
+++ b/lib/flutter_duration_picker.dart
@@ -576,7 +576,8 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
               snapToMins: widget.snapToMins,
             )));
 
-    final Widget actions = new ButtonTheme.bar(
+    final Widget actions = new ButtonBarTheme(
+        data: ButtonBarTheme.of(context),
         child: new ButtonBar(children: <Widget>[
           new FlatButton(
               child: new Text(localizations.cancelButtonLabel),


### PR DESCRIPTION
…ethod-not-found-buttontheme-bar

ButtonTheme.bar is Deprecated. We need to use ButtonBarTheme instead which offers more flexibility to configure ButtonBar widgets. This feature was deprecated after v1.9.1.

So need to change

final Widget actions = new ButtonTheme.bar(

to

final Widget actions = new ButtonBarTheme(
  data: ButtonBarTheme.of(context),

on line 579 of flutter_duration_picker.dart